### PR TITLE
allow symfony process v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "psr/log": "~1.0.0",
         "guzzlehttp/guzzle": "~6.0",
         "pear/crypt_gpg": "^1.6.0",
-        "symfony/process": "^2.7"
+        "symfony/process": "^4.0||^3.0||^2.7"
     },
     "require-dev": {
         "phpunit/phpunit": "^5",


### PR DESCRIPTION
Nahodil jsem si novou komponentu pomocí generátoru a chtěl jsem nainstalovat klienta a zařvalo mi to na vyžadované verzi process ^4.0.

Stejně to máme nastavené u SAPI klienta https://github.com/keboola/storage-api-php-client/blob/631a3675a68bb32fdd488aa54415e349feee8373/composer.json#L23