### PR TITLE
support sso using PGP json login

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     ],
     "require": {
         "php": ">=5.6",
+        "ext-json": "*",
         "psr/log": "~1.0.0",
         "guzzlehttp/guzzle": "~6.0",
         "pear/crypt_gpg": "^1.6.0",

--- a/src/Keboola/GoodData/SSO.php
+++ b/src/Keboola/GoodData/SSO.php
@@ -26,6 +26,11 @@ class SSO
 
     public function getUrl($user, $key, $provider, $targetUrl, $email, $validity = 86400, $keyPass = null)
     {
+        return $this->getClaims($user, $key, $provider, $targetUrl, $email, $validity, $keyPass)['link'];
+    }
+
+    public function getClaims($user, $key, $provider, $targetUrl, $email, $validity = 86400, $keyPass = null)
+    {
         $signData = json_encode(['email' => $email, 'validity' => time() + $validity]);
 
         $gpg = new Crypt_GPG();
@@ -41,12 +46,16 @@ class SSO
             throw new \Exception("Sso generation for user $email using admin $user failed, session id is empty.");
         }
 
-        return sprintf(
-            "%s/gdc/account/customerlogin?sessionId=%s&serverURL=%s&targetURL=%s",
-            $this->baseUri,
-            urlencode($result),
-            urlencode($provider),
-            urlencode($targetUrl)
-        );
+        return [
+            'encryptedClaims' => $result,
+            'ssoProvider' => $provider,
+            'link' => sprintf(
+                "%s/gdc/account/customerlogin?sessionId=%s&serverURL=%s&targetURL=%s",
+                $this->baseUri,
+                urlencode($result),
+                urlencode($provider),
+                urlencode($targetUrl)
+            ),
+        ];
     }
 }

--- a/tests/Keboola/GoodData/ClientTest.php
+++ b/tests/Keboola/GoodData/ClientTest.php
@@ -59,13 +59,6 @@ class ClientTest extends AbstractClientTest
         }
 
         try {
-            $this->client->jsonRequest('GET', '/gdc/'.uniqid());
-            $this->fail();
-        } catch (Exception $e) {
-            $this->assertEquals(404, $e->getCode());
-        }
-
-        try {
             $this->client->jsonRequest('GET', '/gdc/projects/'.uniqid());
             $this->fail();
         } catch (Exception $e) {

--- a/tests/Keboola/GoodData/SSOTest.php
+++ b/tests/Keboola/GoodData/SSOTest.php
@@ -13,16 +13,23 @@ use Keboola\GoodData\SSO;
 
 class SSOTest extends \PHPUnit_Framework_TestCase
 {
-    public function testSSO()
-    {
-        $pid = Helper::getSomeProject();
-        $user = Helper::getSomeUser();
-        Helper::getClient()->getProjects()->addUser($pid, $user['uid']);
+    protected $pid;
+    protected $user;
 
-        $targetUrl = "/#s=/gdc/projects/$pid|projectDashboardPage";
+    protected function setUp()
+    {
+        $this->pid = Helper::getSomeProject();
+        $this->user = Helper::getSomeUser();
+        Helper::getClient()->getProjects()->addUser($this->pid, $this->user['uid']);
+        parent::setUp();
+    }
+
+    public function testSSOLink()
+    {
+        $targetUrl = "/#s=/gdc/projects/{$this->pid}|projectDashboardPage";
 
         $sso = new SSO(null, null, KBGDC_API_URL);
-        $ssoLink = $sso->getUrl(KBGDC_USERNAME, KBGDC_SSO_KEY, KBGDC_SSO_PROVIDER, $targetUrl, $user['email'], 3600, KBGDC_SSO_KEY_PASS);
+        $ssoLink = $sso->getUrl(KBGDC_USERNAME, KBGDC_SSO_KEY, KBGDC_SSO_PROVIDER, $targetUrl, $this->user['email'], 3600, KBGDC_SSO_KEY_PASS);
 
         $stack = \GuzzleHttp\HandlerStack::create();
         $lastRequest = null;
@@ -45,6 +52,54 @@ class SSOTest extends \PHPUnit_Framework_TestCase
                 $this->fail("$response on link: $ssoLink");
             } else {
                 $this->fail($e->getMessage() . " on link: $ssoLink");
+            }
+        }
+        /** @var Request $lastRequest */
+        $result = $lastRequest->getUri()->__toString();
+        $this->assertStringEndsWith($targetUrl, urldecode($result));
+    }
+
+    public function testSSOClaims()
+    {
+        $targetUrl = "/#s=/gdc/projects/{$this->pid}|projectDashboardPage";
+
+        $sso = new SSO(null, null, KBGDC_API_URL);
+        $claims = $sso->getClaims(KBGDC_USERNAME, KBGDC_SSO_KEY, KBGDC_SSO_PROVIDER, $targetUrl, $this->user['email'], 3600, KBGDC_SSO_KEY_PASS);
+
+        $stack = \GuzzleHttp\HandlerStack::create();
+        $lastRequest = null;
+        $stack->push(\GuzzleHttp\Middleware::mapRequest(function (Request $request) use (&$lastRequest) {
+            $lastRequest = $request;
+            return $request;
+        }));
+        $client = new Client([
+            'handler' => $stack,
+            \GuzzleHttp\RequestOptions::ALLOW_REDIRECTS => true,
+            'verify' => false
+        ]);
+        try {
+            $client->request(
+                'POST',
+                'https://secure.gooddata.com/gdc/account/customerlogin',
+                [
+                    'headers' => [
+                        'Accept' => 'application/json'
+                    ],
+                    'json' => [
+                        'pgpLoginRequest' => [
+                            'encryptedClaims' => $claims['encryptedClaims'],
+                            'ssoProvider' => $claims['ssoProvider'],
+                            'targetUrl' => $targetUrl,
+                        ],
+                    ],
+                ]
+            );
+        } catch (RequestException $e) {
+            if ($e->hasResponse()) {
+                $response = $e->getResponse()->getBody();
+                $this->fail("$response on claims: " . print_r($claims));
+            } else {
+                $this->fail($e->getMessage() . " on claims: " . print_r($claims));
             }
         }
         /** @var Request $lastRequest */


### PR DESCRIPTION
Nejdřív je to potřeba přidat sem do klienta a ty `encryptedClaims` a `ssoProvider` potom vrátí starej Writer v API callu.