### PR TITLE
fix: date dimension with custom identifier

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -344,10 +344,10 @@ class Client
             }
         }
 
-        $identifier = !empty($params['identifier']) ? $params['identifier']
-            : $this->getDateDimensions()->getDefaultIdentifier($params['name']);
+        $customIdentifier = !empty($params['identifier']) ? $params['identifier'] : null;
+        $identifier = $customIdentifier ?: $this->getDateDimensions()->getDefaultIdentifier($params['name']);
         $template = !empty($params['template']) ? $params['template'] : null;
-        if (!$this->getDateDimensions()->exists($params['pid'], $params['name'], $template)) {
+        if (!$this->getDateDimensions()->exists($params['pid'], $params['name'], $template, $customIdentifier)) {
             $this->getDateDimensions()->executeCreateMaql($params['pid'], $params['name'], $identifier, $template);
         }
         if (!empty($params['includeTime'])) {

--- a/src/DateDimensions.php
+++ b/src/DateDimensions.php
@@ -44,14 +44,17 @@ class DateDimensions
         return $result;
     }
 
-    public function exists($pid, $name, $template = null)
+    public function exists($pid, $name, $template = null, $customIdentifier = null)
     {
         $call = $this->client->get("/gdc/md/$pid/data/sets");
         $existingDataSets = [];
         foreach ($call['dataSetsInfo']['sets'] as $r) {
             $existingDataSets[] = $r['meta']['identifier'];
         }
-        return in_array(Identifiers::getDateDimensionId($name, $template), $existingDataSets);
+        return in_array(
+            Identifiers::getDateDimensionId($name, $template, $customIdentifier),
+            $existingDataSets
+        );
     }
 
     public function executeCreateMaql($pid, $name, $identifier, $template = null)
@@ -64,12 +67,10 @@ class DateDimensions
         ));
     }
 
-    public function create($pid, $name, $identifier = null, $template = null)
+    public function create($pid, $name, $customIdentifier = null, $template = null)
     {
-        if (!$identifier) {
-            $identifier = $this->getDefaultIdentifier($name);
-        }
-        if (!$this->exists($pid, $name, $template)) {
+        $identifier = $customIdentifier ?: $this->getDefaultIdentifier($name);
+        if (!$this->exists($pid, $name, $template, $customIdentifier)) {
             $this->executeCreateMaql($pid, $name, $identifier, $template);
         }
     }

--- a/src/Identifiers.php
+++ b/src/Identifiers.php
@@ -52,17 +52,18 @@ class Identifiers
             self::getIdentifier($attrName)
         );
     }
-    
+
     public static function getDateDimensionGrainId($name, $template = null)
     {
         $template = strtolower($template);
         return self::getIdentifier($name) . (($template && $template != 'gooddata') ? ".$template" : "");
     }
 
-    public static function getDateDimensionId($name, $template = null)
+    public static function getDateDimensionId($name, $template = null, $customIdentifier = null)
     {
         $template = strtolower($template);
-        return self::getIdentifier($name)
+        $identifier = $customIdentifier ?: self::getIdentifier($name);
+        return $identifier
             . (($template && $template != 'gooddata') ? '.' . $template : null) . '.dataset.dt';
     }
 }

--- a/tests/DateDimensionsTest.php
+++ b/tests/DateDimensionsTest.php
@@ -22,6 +22,25 @@ class DateDimensionTest extends AbstractClientTest
         $this->assertTrue(in_array(Identifiers::getDateDimensionId($name), $this->getDataSets($pid)));
     }
 
+    public function testCreateDateDimensionCustomIdentifier()
+    {
+        $pid = Helper::getSomeProject();
+        Helper::cleanUpProject($pid);
+
+        $name = 'd' . uniqid();
+        $identifier = 'customId' . rand(1, 128);
+        $this->client->createDateDimension([
+            'pid' => $pid,
+            'name' => $name,
+            'identifier' => $identifier,
+        ]);
+
+        $this->assertTrue(in_array(
+            Identifiers::getDateDimensionId($name, null, $identifier),
+            $this->getDataSets($pid)
+        ));
+    }
+
     public function testCreateDateDimensionTemplateDateOnly()
     {
         $pid = Helper::getSomeProject();


### PR DESCRIPTION
Problém byl tady: https://github.com/keboola/gooddata-php-client/pull/8/files#diff-317758c3495fdb082d415723a56dbaf4R47 Testuje se jestli dimenze existuje v GD, jinak se vyrobí. Jenže kvůli custom identifikátoru se ten test blbě prováděl.